### PR TITLE
Fix Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ jobs:
       script:
         - ./gradlew test jvmTest ktlintCheck --parallel
     - name: iOS
+      os: osx
+      osx_image: xcode10.2
       language: swift
       before_cache:
         - brew cleanup


### PR DESCRIPTION
# Description

Because of `swiftlint` Travis-CI build would fail because of this error:
```
swiftlint: A full installation of Xcode.app 10.2 is required to compile
this software. Installing just the Command Line Tools is not sufficient.
Xcode 10.2 cannot be installed on macOS 10.13.
You must upgrade your version of macOS.
```

## Work Done

* Change the required osx_image to be with xcode10.2
