### PR TITLE
Remove PascalCase for project name constraint

### DIFF
--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -66,13 +66,7 @@ run() {
 # Execution
 # -----------------------------------------------------------------------------
 
-argumentIsPascalCase=false
-while [ ${argumentIsPascalCase} == "false" ]
-do
-  read -p $'\nWhat is your project name? (Should be in PascalCase)\n' USER_INPUT
-  isPascalCase "$USER_INPUT"
-done
-PROJECT_NAME=${USER_INPUT}
+read -p $'\nWhat is your project name?\n' PROJECT_NAME
 
 argumentIsPascalCase=false
 while [ ${argumentIsPascalCase} == "false" ]


### PR DESCRIPTION
# Description

This PR removes the validation on a project name to check if it's in a `PascalCase` format. The user can now name the project however he wants.