### PR TITLE
Fix missing dSYM issue when archiving iOS project

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -146,7 +146,7 @@ task copyFramework() {
             from srcFile.parent
             into targetDir
             include "${frameworkFilename}/**"
-            include "${frameworkFilename}.dSYM"
+            include "${frameworkFilename}.dSYM/**"
         }
         copy {
             from translationDir


### PR DESCRIPTION
Fix the following error message when trying to archive the iOS project.

```
Users/admin/Jenkins/jenkins-root/workspace/MyProject/my-project-name/ios/Pods/../../common/build/bin/ios/MyCommonFramework.framework.dSYM/Contents/Resources/DWARF: No such file or directory
```