### PR TITLE
Fix missing kword gradle task before iOS build

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -156,4 +156,4 @@ task copyFramework() {
     }
 }
 
-tasks.findAll { it.name.startsWith('preBuild') }.each { it.dependsOn('kwordGenerateEnum') }
+tasks.findAll { it.name.startsWith('preBuild') || it.name.startsWith('copyFramework') }.each { it.dependsOn('kwordGenerateEnum') }


### PR DESCRIPTION
Fix compilation issue when building iOS project with usage of Kword in common code. The `kwordGenerateEnum` gradle task was simply not run. 

The fix here is to make sure the `copyFramework` iOS task depends on `kwordGenerateEnum`.