### PR TITLE
Fix ktlint check issue caused by unused import

### DIFF
--- a/common/src/commonMain/kotlin/com/trikot/sample/repositories/impl/QuoteRepositoryImpl.kt
+++ b/common/src/commonMain/kotlin/com/trikot/sample/repositories/impl/QuoteRepositoryImpl.kt
@@ -6,7 +6,6 @@ import com.mirego.trikot.streams.reactive.ColdPublisher
 import com.trikot.sample.models.Quote
 import com.trikot.sample.repositories.QuoteRepository
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.builtins.list
 import org.reactivestreams.Publisher
 
 class QuoteRepositoryImpl() : QuoteRepository {


### PR DESCRIPTION
When opening a new Pull Request, the build is failing because of the following unused import in `QuoteRepositoryImpl.kt`.

```kotlin
import kotlinx.serialization.builtins.list
```