### PR TITLE
Fix warning caused by wrong framework_search_path

### DIFF
--- a/ios/iosApp.xcodeproj/project.pbxproj
+++ b/ios/iosApp.xcodeproj/project.pbxproj
@@ -620,7 +620,7 @@
 				DEVELOPMENT_TEAM = 4Q596JWQC5;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$SRCROOT/../common-mobile/build/bin/ios/**",
+					"$SRCROOT/../common/build/bin/ios/**",
 					"$(inherited)",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";


### PR DESCRIPTION
When archiving an iOS project, a warning is triggered because the FRAMEWORK_SEARCH_PATHS for the Release config cannot be found.

```
...
INFO [2020-10-26 19:25:59.32]: ▸ Linking iosApp
INFO [2020-10-26 19:25:59.33]: ▸ ⚠️  ld: directory not found for option '#{jenkins-root}/workspace/MyProject/MyProjectName/ProjectName/ios/../common-mobile/build/bin/ios'
....
```