### PR TITLE
Remove references of deprecated Fabric sdk

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -190,7 +190,6 @@ atlassian-ide-plugin.xml
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
-fabric.properties
 
 ### AndroidStudio Patch ###
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ buildscript {
         google()
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://maven.fabric.io/public' }
     }
 
     dependencies {
@@ -12,7 +11,6 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.1'
-        classpath 'io.fabric.tools:gradle:1.29.0'
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:8.0.0'
     }
 }


### PR DESCRIPTION
The Fabric SDK is deprecated and Firebase Crashlytics should be used instead.

See https://firebase.google.com/docs/crashlytics/upgrade-sdk for reference.