### PR TITLE
Add jacoco and coveralls to trikot.patron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,6 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew check --parallel
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: ./gradlew :common:check :common:jacocoTestReport :common:coverallsJacoco

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      #Remove comments here to enable coveralls!
       - name: Build with Gradle
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew :common:check :common:jacocoTestReport :common:coverallsJacoco
+        #env:
+          #COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: ./gradlew :common:check :common:jacocoTestReport #:common:coverallsJacoco

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,11 @@ buildscript {
 
     dependencies {
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0"
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.1'
-        classpath 'org.jlleitschuh.gradle:ktlint-gradle:8.0.0'
+        classpath 'com.google.gms:google-services:4.3.4'
+        classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.1.1'
     }
 }
 
@@ -21,6 +21,11 @@ repositories {
 }
 
 allprojects {
+    buildscript {
+        repositories {
+            google()
+        }
+    }
     repositories {
         google()
         jcenter()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'kotlinx-serialization'
     id 'org.jlleitschuh.gradle.ktlint'
     id 'mirego.kword' version '0.5'
+    id 'jacoco'
+    id "com.github.nbaztec.coveralls-jacoco" version "1.2.4"
 }
 
 repositories {
@@ -157,3 +159,42 @@ task copyFramework() {
 }
 
 tasks.findAll { it.name.startsWith('preBuild') || it.name.startsWith('copyFramework') }.each { it.dependsOn('kwordGenerateEnum') }
+
+jacoco {
+    toolVersion = "0.8.2"
+    reportsDir = file("build/reports")
+}
+
+task jacocoTestReport(type: JacocoReport, dependsOn: "test") {
+    group = "Reporting"
+    description = "Generate Jacoco coverage reports"
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def excludes = [
+            '**/serializer.class',
+            '**/factories**'
+    ]
+    getClassDirectories().setFrom(fileTree(
+            dir: "build/intermediates/classes/debug",
+            excludes: excludes
+    ) + fileTree(
+            dir: "build/tmp/kotlin-classes/debug",
+            excludes: excludes
+    ))
+    getExecutionData().setFrom(files("build/jacoco/testDebugUnitTest.exec"))
+    getSourceDirectories().setFrom(files([
+            "src/commonMain/kotlin"
+    ]))
+}
+tasks.find { it.name.find('coverallsJacoco') }.mustRunAfter jacocoTestReport
+
+coverallsJacoco {
+    reportPath = "${buildDir}/reports/jacocoTestReport/jacocoTestReport.xml"
+    reportSourceSets = files([
+            "src/commonMain/kotlin"
+    ])
+}

--- a/common/src/commonMain/kotlin/com/trikot/sample/Environment.kt
+++ b/common/src/commonMain/kotlin/com/trikot/sample/Environment.kt
@@ -1,7 +1,7 @@
 package com.trikot.sample
 
-import com.mirego.trikot.http.HttpConfiguration
 import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.http.HttpConfiguration
 
 object Environment {
     private val internalFlavor = AtomicReference(Environment.Flavor.RELEASE)

--- a/common/src/commonMain/kotlin/com/trikot/sample/viewmodels/home/HomeViewModelController.kt
+++ b/common/src/commonMain/kotlin/com/trikot/sample/viewmodels/home/HomeViewModelController.kt
@@ -3,8 +3,8 @@ package com.trikot.sample.viewmodels.home
 import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.streams.reactive.RefreshablePublisher
 import com.trikot.sample.domain.FetchQuoteUseCase
-import com.trikot.sample.viewmodels.base.BaseViewModelController
 import com.trikot.sample.viewmodels.base.BaseNavigationDelegate
+import com.trikot.sample.viewmodels.base.BaseViewModelController
 import com.trikot.sample.viewmodels.home.impl.HomeViewModelImpl
 
 class HomeViewModelController(


### PR DESCRIPTION
This PR adds Jacoco with some default configs and Coveralls for test coverage. It also assumes that only the common code will be tested by the CI. 

I also took the liberty of updating a couple of plugins.

⚠️ The CI will fail for new projects if the new project is not set-up with Coveralls and have a valid "COVERALLS_REPO_TOKEN" in Github's repo secrets 