### PR TITLE
Fix kotlin version of the coveralls jacoco gradle plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ android {
         applicationId "com.trikot.sample"
         versionCode 1
         versionName "1.0"
-        archivesBaseName = "PatronProjectName-$versionCode"
+        archivesBaseName = "TrikotFrameworkName-$versionCode"
 
         minSdkVersion 21
         targetSdkVersion 30
@@ -74,7 +74,6 @@ configurations.all {
 
 dependencies {
     api project(':common')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version"
 
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    dependencies {
+        classpath("com.github.nbaztec:coveralls-jacoco-gradle-plugin:1.2.5") {
+            // The plugin is using an older version (1.3.72) which prevent us from using 1.4+
+            // https://github.com/nbaztec/coveralls-jacoco-gradle-plugin/blob/main/build.gradle.kts#L35
+            exclude group: 'org.jetbrains.kotlin', module: 'kotlin-gradle-plugin'
+        }
+    }
+}
+
 plugins {
     id 'com.android.library'
     id 'kotlin-multiplatform'
@@ -5,8 +15,9 @@ plugins {
     id 'org.jlleitschuh.gradle.ktlint'
     id 'mirego.kword' version '0.5'
     id 'jacoco'
-    id 'com.github.nbaztec.coveralls-jacoco' version '1.2.4'
 }
+// We must use this approach to load the plugin since we enforced the exclusion of a transitive dependency
+apply plugin: 'com.github.nbaztec.coveralls-jacoco'
 
 repositories {
     google()
@@ -21,7 +32,7 @@ repositories {
 group 'com.trikot.sample'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig {
         minSdkVersion 21
     }


### PR DESCRIPTION
## 📖 Description

Jacoco's coveralls plugin was preventing the usage of Kotlin 1.4 within the IDE.

We make sure to remove the transitive dependency from the plugin prior to loading it.

## 🗒️  Notes

Also adjusted a few discrepancies found during the integration of patron in a new project.

## 🦀 Dispatch
		
- `#dispatch/kmp`

## 🎉 Result

| Before | After |
| ------ | ------ |
| ![Screen Shot 2021-01-04 at 15 29 26](https://user-images.githubusercontent.com/513491/103651996-6c5d2400-4f30-11eb-85f9-94e7f9e130ac.png) | ![Screen Shot 2021-01-05 at 08 30 09](https://user-images.githubusercontent.com/513491/103651999-6c5d2400-4f30-11eb-9517-4ecaa252d3ea.png) |