### PR TITLE
Add tvOS target to podspec

### DIFF
--- a/common/TrikotFrameworkName.podspec
+++ b/common/TrikotFrameworkName.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
     spec.summary                  = 'Awesome library'
 
     spec.static_framework         = true
-    spec.vendored_frameworks      = "build/bin/ios/TrikotFrameworkName.framework"
+    spec.vendored_frameworks      = "build/bin/TrikotFrameworkName.framework"
     spec.libraries                = "c++", "System"
     spec.module_name              = "#{spec.name}_umbrella"
 
@@ -16,7 +16,9 @@ Pod::Spec.new do |spec|
         'KOTLIN_BUILD_TYPE[config=Debug]' => 'DEBUG',
         'KOTLIN_BUILD_TYPE[config=Release]' => 'RELEASE',
         'KOTLIN_TARGET[sdk=iphonesimulator*]' => 'iosX64',
-        'KOTLIN_TARGET[sdk=iphoneos*]' => 'iosArm64'
+        'KOTLIN_TARGET[sdk=iphoneos*]' => 'iosArm64',
+        'KOTLIN_TARGET[sdk=appletvos*]' => 'tvosArm64',
+        'KOTLIN_TARGET[sdk=appletvsimulator*]' => 'tvosX64'
     }
 
     spec.prepare_command = <<-CMD
@@ -41,7 +43,7 @@ then
   fi
 
   ./gradlew :common:copyFramework \
-    -Pconfiguration.build.dir="build/bin/ios" \
+    -Pconfiguration.build.dir="build/bin" \
     -Pkotlin.build.type="$KOTLIN_BUILD_TYPE" \
     -Pkotlin.target="$KOTLIN_TARGET"
 else


### PR DESCRIPTION
## 💻  Description
When building tvOS app the iOS framework was used. Now it uses `tvosArm64` or `tvosX64`.

## 🗒️  Note

You still need to add to your `build.gradle`:
```
kotlin{
   tvos() {binaries {...}}
   sourceSet {
       nativeMain {
            dependsOn commonMain
        }

        iosMain {
            dependsOn nativeMain
        }

        tvosMain {
            dependsOn nativeMain
        }
  }
}
```
but since most people will remove it, I don't think it's a good idea to update `build.gradle` file.