### PR TITLE
Add boilerplate projects introduction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This repository is the stable base upon which we build our mobile projects at Mirego.
 We want to share it with the world so you can build awesome mobile applications too.
 
+## Introduction
+
+To learn more about _why_ we created and maintain this boilerplate project, read our [blog post](https://shift.mirego.com/en/boilerplate-projects).
+
 ## Usage
 
 ### Setting up the project
@@ -24,6 +28,7 @@ We want to share it with the world so you can build awesome mobile applications 
 
 - ./jobs/build_jobs.groovy
 - ./jobs/ios_fastlane.groovy
+
 ```
 String clientName = 'SAMPLECLIENT'.toLowerCase().replaceAll(' ','_')
 String projectName = 'SAMPLEPROJECT'.toLowerCase().replaceAll(' ','_')


### PR DESCRIPTION
## 📖 Description

I recently updated [our blog post on boilerplate projects](https://shift.mirego.com/en/boilerplate-projects) to include Trikot.patron among our other boilerplate projects.

It seems logical to add the same introductory context to `README.md` like we have in our other projects 🙂
