### PR TITLE
Switch to cocoapod gradle plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,5 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      #Remove comments here to enable coveralls!
       - name: Build with Gradle
-        #env:
-          #COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew :common:check :common:jacocoTestReport #:common:coverallsJacoco
+        run: ./gradlew :common:check

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -7,16 +7,15 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Versions.COMPILE_SDK)
-
     defaultConfig {
         applicationId = "com.trikot.sample"
         versionCode = 1
         versionName = "1.0"
         versionName = "1.0"
 
-        minSdkVersion(Versions.MIN_SDK)
-        targetSdkVersion(Versions.TARGET_SDK)
+        compileSdk = Versions.COMPILE_SDK
+        minSdk = Versions.MIN_SDK
+        targetSdk = Versions.TARGET_SDK
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -47,9 +46,9 @@ android {
         dataBinding = true
     }
 
-    lintOptions {
-        isCheckReleaseBuilds = true
-        isAbortOnError = true
+    lint {
+        checkReleaseBuilds = true
+        abortOnError = true
     }
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -15,7 +15,10 @@
         android:supportsRtl="true"
         tools:ignore="GoogleAppIndexingWarning">
 
-        <activity android:name=".MainActivity" android:theme="@style/Theme.AppCompat.Light">
+        <activity
+            android:name=".MainActivity"
+            android:theme="@style/Theme.AppCompat.Light"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/android/src/main/java/com/trikot/sample/common/AndroidViewModelProviderFactory.kt
+++ b/android/src/main/java/com/trikot/sample/common/AndroidViewModelProviderFactory.kt
@@ -53,7 +53,7 @@ class AndroidViewModelProviderFactory {
         private val internalFactory = Bootstrap.shared.viewModelControllerFactory
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             val getters = internalFactory::class.java.declaredMethods
                 .filter {
                     it.returnType == modelClass && it.parameterTypes.map { javaClass ->

--- a/buildSrc/src/main/java/Libs.kt
+++ b/buildSrc/src/main/java/Libs.kt
@@ -21,7 +21,7 @@ object Libs {
         const val ConstraintLayout =
             "androidx.constraintlayout:constraintlayout:${Versions.ANDROIDX_CONSTRAINT_LAYOUT}"
         const val LifecycleExtensions =
-            "androidx.lifecycle:lifecycle-extensions:${Versions.ANDROIDX_LIFECYCLE}"
+            "androidx.lifecycle:lifecycle-extensions:${Versions.ANDROIDX_LIFECYCLE_EXTENSIONS}"
         const val LifecycleViewModel =
             "androidx.lifecycle:lifecycle-viewmodel:${Versions.ANDROIDX_LIFECYCLE}"
         const val LifecycleViewModelKtx =

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,17 +1,18 @@
 object Versions {
 
-    const val COMPILE_SDK = 30
-    const val TARGET_SDK = 30
+    const val COMPILE_SDK = 31
+    const val TARGET_SDK = 31
     const val MIN_SDK = 21
 
-    const val KOTLIN = "1.5.31"
-    const val ANDROID_GRADLE_PLUGIN = "7.1.0-rc01"
+    const val KOTLIN = "1.6.20"
+    const val ANDROID_GRADLE_PLUGIN = "7.2.0"
     const val GOOGLE_SERVICES_PLUGIN = "4.3.10"
     const val KTLINT = "10.2.0"
-    const val KOTLINX_SERIALIZATION = "1.1.0"
+    const val KOTLINX_SERIALIZATION = "1.3.2"
     const val ANDROID_APP_COMPAT = "1.2.0"
     const val ANDROIDX_CONSTRAINT_LAYOUT = "2.0.4"
-    const val ANDROIDX_LIFECYCLE = "2.2.0"
+    const val ANDROIDX_LIFECYCLE_EXTENSIONS = "2.2.0"
+    const val ANDROIDX_LIFECYCLE = "2.4.0"
     const val ANDROID_MATERIAL = "1.0.0"
     const val PICASSO = "2.71828"
 

--- a/common/TrikotFrameworkName.podspec
+++ b/common/TrikotFrameworkName.podspec
@@ -1,55 +1,39 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'TrikotFrameworkName'
-    spec.version                  = '0.0.1'
+    spec.version                  = '1.0.0'
     spec.homepage                 = 'www.mirego.com'
-    spec.source                   = { :git => "Not Published", :tag => "Cocoapods/#{spec.name}/#{spec.version}" }
+    spec.source                   = { :http=> ''}
     spec.authors                  = ''
-    spec.license                  = 'No license'
-    spec.summary                  = 'Awesome library'
-
-    spec.static_framework         = true
-    spec.vendored_frameworks      = "build/bin/TrikotFrameworkName.framework"
-    spec.libraries                = "c++", "System"
-    spec.module_name              = "#{spec.name}_umbrella"
-
+    spec.license                  = 'BSD-3'
+    spec.summary                  = 'Trikot.Patron'
+    spec.vendored_frameworks      = 'build/cocoapods/framework/TrikotFrameworkName.framework'
+    spec.libraries                = 'c++'
+                
+                
+                
     spec.pod_target_xcconfig = {
-        'KOTLIN_BUILD_TYPE[config=Debug]' => 'DEBUG',
-        'KOTLIN_BUILD_TYPE[config=Release]' => 'RELEASE',
-        'KOTLIN_TARGET[sdk=iphonesimulator*]' => 'iosX64',
-        'KOTLIN_TARGET[sdk=iphoneos*]' => 'iosArm64',
-        'KOTLIN_TARGET[sdk=appletvos*]' => 'tvosArm64',
-        'KOTLIN_TARGET[sdk=appletvsimulator*]' => 'tvosX64'
+        'KOTLIN_PROJECT_PATH' => ':common',
+        'PRODUCT_MODULE_NAME' => 'TrikotFrameworkName',
     }
-
-    spec.prepare_command = <<-CMD
-        ../gradlew :common:copyFramework -Pconfiguration.build.dir="build/bin/ios"
-    CMD
-
+                
     spec.script_phases = [
         {
-            :name => 'Build common',
+            :name => 'Build TrikotFrameworkName',
             :execution_position => :before_compile,
             :shell_path => '/bin/sh',
             :script => <<-SCRIPT
-if [ "$ENABLE_PREVIEWS" = "NO" ]
-then
-  echo "Building common framework"
-
-  cd "$SRCROOT/../.."
-  pwd
-  FILE=.env.sh
-  if [ -f $FILE ]; then
-    source .env.sh
-  fi
-
-  ./gradlew :common:copyFramework \
-    -Pconfiguration.build.dir="build/bin" \
-    -Pkotlin.build.type="$KOTLIN_BUILD_TYPE" \
-    -Pkotlin.target="$KOTLIN_TARGET"
-else
-  echo "Skipping build of common framework in preview mode"
-fi
+                if [ "YES" = "$COCOAPODS_SKIP_KOTLIN_BUILD" ]; then
+                  echo "Skipping Gradle build task invocation due to COCOAPODS_SKIP_KOTLIN_BUILD environment variable set to \"YES\""
+                  exit 0
+                fi
+                set -ev
+                REPO_ROOT="$PODS_TARGET_SRCROOT"
+                "$REPO_ROOT/../gradlew" -p "$REPO_ROOT" $KOTLIN_PROJECT_PATH:syncFramework \
+                    -Pkotlin.native.cocoapods.platform=$PLATFORM_NAME \
+                    -Pkotlin.native.cocoapods.archs="$ARCHS" \
+                    -Pkotlin.native.cocoapods.configuration="$CONFIGURATION"
             SCRIPT
         }
     ]
+    spec.resources = "src/commonMain/resources/translations/*"
 end

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,23 +1,10 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
-buildscript {
-    dependencies {
-        classpath("com.github.nbaztec:coveralls-jacoco-gradle-plugin:1.2.5") {
-            // The plugin is using an older version (1.3.72) which prevent us from using 1.4+
-            // https://github.com/nbaztec/coveralls-jacoco-gradle-plugin/blob/main/build.gradle.kts#L35
-            exclude(group = "org.jetbrains.kotlin", module = "kotlin-gradle-plugin")
-        }
-    }
-}
-
 plugins {
+    kotlin("multiplatform")
+    kotlin("native.cocoapods")
     id("com.android.library")
-    id("kotlin-multiplatform")
     id("kotlinx-serialization")
     id("org.jlleitschuh.gradle.ktlint")
     id("mirego.kword") version Versions.TRIKOT_KWORD_PLUGIN
-    id("jacoco")
-    id("com.github.nbaztec.coveralls-jacoco") version "1.2.12"
 }
 
 repositories {
@@ -29,9 +16,9 @@ repositories {
 }
 
 android {
-    compileSdkVersion(Versions.COMPILE_SDK)
     defaultConfig {
-        minSdkVersion(Versions.MIN_SDK)
+        compileSdk = Versions.COMPILE_SDK
+        minSdk = Versions.MIN_SDK
     }
 }
 
@@ -41,30 +28,54 @@ kword {
     generatedDir("src/commonMain/generated")
 }
 
+fun org.jetbrains.kotlin.gradle.plugin.mpp.Framework.configureFramework() {
+    embedBitcode("disable")
+    baseName = Const.TRIKOT_FRAMEWORK_NAME
+    transitiveExport = true
+    export(SharedLibs.Trikot.Foundation)
+    export(SharedLibs.Trikot.Streams)
+    export(SharedLibs.Trikot.Viewmodels)
+    export(SharedLibs.Trikot.Http)
+    export(SharedLibs.Trikot.Kword)
+}
+
 kotlin {
     android {
         publishAllLibraryVariants()
     }
 
+    cocoapods {
+        this.name = Const.TRIKOT_FRAMEWORK_NAME
+        summary = "Trikot.Patron"
+        homepage = "www.mirego.com"
+        license = "BSD-3"
+        extraSpecAttributes = mutableMapOf(
+            "resources" to "\"src/commonMain/resources/translations/*\""
+        )
+
+        framework {
+            configureFramework()
+        }
+    }
+
     ios {
-        binaries {
-            framework {
-                embedBitcode("disable")
-                baseName = Const.TRIKOT_FRAMEWORK_NAME
-                transitiveExport = true
-                export(SharedLibs.Trikot.Foundation)
-                export(SharedLibs.Trikot.Streams)
-                export(SharedLibs.Trikot.Viewmodels)
-                export(SharedLibs.Trikot.Http)
-                export(SharedLibs.Trikot.Kword)
-            }
+        binaries.framework {
+            configureFramework()
+        }
+    }
+
+    iosSimulatorArm64 {
+        binaries.framework {
+            configureFramework()
         }
     }
 
     sourceSets {
         all {
-            languageSettings.useExperimentalAnnotation("kotlin.Experimental")
-            languageSettings.useExperimentalAnnotation("kotlin.time.ExperimentalTime")
+            languageSettings {
+                optIn("kotlin.ExperimentalStdlibApi")
+                optIn("kotlin.time.ExperimentalTime")
+            }
         }
 
         val commonMain by getting {
@@ -109,80 +120,11 @@ kotlin {
     }
 }
 
-// This task attaches native framework built from ios module to Xcode project
-// (see iosApp directory). Don't run this task directly,
-// Xcode runs this task itself during its build process.
-// Before opening the project from iosApp directory in Xcode,
-// make sure all Gradle infrastructure exists (gradle.wrapper, gradlew).
-val copyFramework by tasks.creating {
-    val buildType = project.findProperty("kotlin.build.type")?.toString() ?: "RELEASE"
-    val target = project.findProperty("kotlin.target")?.toString() ?: "iosArm64"
-    val kotlinNativeTarget = kotlin.targets.getByName<KotlinNativeTarget>(target)
-    val framework = kotlinNativeTarget.binaries.getFramework(buildType)
-    dependsOn(framework.linkTask)
-
-    doLast {
-        val srcFile = framework.outputFile
-        val targetDir = project.property("configuration.build.dir")
-        val frameworkDir = "$targetDir/${Const.TRIKOT_FRAMEWORK_NAME}.framework"
-        val translationDir = "$projectDir/../common/src/commonMain/resources/translations"
-        copy {
-            from(srcFile.parent)
-            into(targetDir)
-            include("${Const.TRIKOT_FRAMEWORK_NAME}.framework/**")
-            include("${Const.TRIKOT_FRAMEWORK_NAME}.framework.dSYM/**")
-        }
-        copy {
-            from(translationDir)
-            into(frameworkDir)
-            include("**")
-        }
-    }
-}
-
 project.afterEvaluate {
     project.tasks.filter { task -> task.name.startsWith("compile") && task.name.contains("Kotlin") }
         .forEach { task ->
             task.dependsOn("kwordGenerateEnum")
         }
-}
-
-jacoco {
-    toolVersion = "0.8.2"
-    reportsDir = file("build/reports")
-}
-
-val jacocoTestReport by tasks.creating(JacocoReport::class) {
-    dependsOn("test")
-    group = "Reporting"
-    description = "Generate Jacoco coverage reports"
-
-    reports {
-        xml.isEnabled = true
-        html.isEnabled = true
-    }
-
-    val excludes: (ConfigurableFileTree) -> Unit = {
-        it.exclude(
-            "**/serializer.class",
-            "**/factories**"
-        )
-    }
-    classDirectories.setFrom(
-        listOf(
-            fileTree("build/intermediates/classes/debug", excludes),
-            fileTree("build/tmp/kotlin-classes/debug", excludes)
-        )
-    )
-    executionData.setFrom(files("build/jacoco/testDebugUnitTest.exec"))
-    sourceDirectories.setFrom(files(listOf("src/commonMain/kotlin")))
-}
-
-tasks.find { it.name == "coverallsJacoco" }?.mustRunAfter(jacocoTestReport)
-
-coverallsJacoco {
-    reportPath = "$buildDir/reports/jacocoTestReport/jacocoTestReport.xml"
-    reportSourceSets = files(listOf("src/commonMain/kotlin"))
 }
 
 ktlint {

--- a/common/src/commonMain/kotlin/com/trikot/sample/domain/impl/FetchQuoteUseCaseImpl.kt
+++ b/common/src/commonMain/kotlin/com/trikot/sample/domain/impl/FetchQuoteUseCaseImpl.kt
@@ -11,7 +11,7 @@ class FetchQuoteUseCaseImpl(private val quoteRepo: QuoteRepository) :
     FetchQuoteUseCase {
     override fun fetchQuote(): Publisher<String> {
         return quoteRepo.getQuotes()
-            .map { it.firstOrNull()?.quote ?: "No quotes" }
+            .map { it.randomOrNull()?.text ?: "No quotes" }
             .onErrorReturn { it.message ?: "Unknown error occurred" }
             .shared()
     }

--- a/common/src/commonMain/kotlin/com/trikot/sample/models/Quote.kt
+++ b/common/src/commonMain/kotlin/com/trikot/sample/models/Quote.kt
@@ -3,4 +3,4 @@ package com.trikot.sample.models
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Quote(val quote: String, val author: String)
+data class Quote(val text: String, val author: String? = null)

--- a/common/src/commonMain/kotlin/com/trikot/sample/repositories/impl/QuoteRepositoryImpl.kt
+++ b/common/src/commonMain/kotlin/com/trikot/sample/repositories/impl/QuoteRepositoryImpl.kt
@@ -12,8 +12,8 @@ class QuoteRepositoryImpl() : QuoteRepository {
     override fun getQuotes(): Publisher<List<Quote>> {
         return ColdPublisher { cancellableManager ->
             val request = RequestBuilder().also {
-                it.baseUrl = "https://breaking-bad-quotes.herokuapp.com"
-                it.path = "/v1/quotes/5"
+                it.baseUrl = "https://type.fit/api"
+                it.path = "/quotes"
             }
 
             DeserializableHttpRequestPublisher(ListSerializer(Quote.serializer()), request).also {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,9 @@
 kotlin.code.style=official
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
+version=1.0.0
 
-trikot_version=3.0.0
+trikot_version=3.3.3
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
   - ReachabilitySwift (5.0.0)
   - SwiftLint (0.39.2)
-  - Trikot/http (1.0.0):
+  - Trikot/http (3.3.3):
     - ReachabilitySwift (~> 5.0)
     - TrikotFrameworkName
-  - Trikot/kword (1.0.0):
+  - Trikot/kword (3.3.3):
     - TrikotFrameworkName
-  - Trikot/streams (1.0.0):
+  - Trikot/streams (3.3.3):
     - TrikotFrameworkName
-  - Trikot/viewmodels (1.0.0):
+  - Trikot/viewmodels (3.3.3):
     - Trikot/streams
     - TrikotFrameworkName
-  - TrikotFrameworkName (0.0.1)
+  - TrikotFrameworkName (1.0.0)
 
 DEPENDENCIES:
   - SwiftLint
-  - "Trikot/http (from `git@github.com:mirego/trikot.git`, tag `3.0.0`)"
-  - "Trikot/kword (from `git@github.com:mirego/trikot.git`, tag `3.0.0`)"
-  - "Trikot/streams (from `git@github.com:mirego/trikot.git`, tag `3.0.0`)"
-  - "Trikot/viewmodels (from `git@github.com:mirego/trikot.git`, tag `3.0.0`)"
+  - "Trikot/http (from `git@github.com:mirego/trikot.git`, tag `3.3.3`)"
+  - "Trikot/kword (from `git@github.com:mirego/trikot.git`, tag `3.3.3`)"
+  - "Trikot/streams (from `git@github.com:mirego/trikot.git`, tag `3.3.3`)"
+  - "Trikot/viewmodels (from `git@github.com:mirego/trikot.git`, tag `3.3.3`)"
   - TrikotFrameworkName (from `../common`)
 
 SPEC REPOS:
@@ -29,20 +29,20 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Trikot:
     :git: "git@github.com:mirego/trikot.git"
-    :tag: 3.0.0
+    :tag: 3.3.3
   TrikotFrameworkName:
     :path: "../common"
 
 CHECKOUT OPTIONS:
   Trikot:
     :git: "git@github.com:mirego/trikot.git"
-    :tag: 3.0.0
+    :tag: 3.3.3
 
 SPEC CHECKSUMS:
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
-  Trikot: ad053a2f4a4903a973729e6e70e8c4f2f159666b
-  TrikotFrameworkName: e7784bc239a138d44a680bf58ac8cd46290906cf
+  Trikot: fe10e97e43bf0ac624b3ac92a2b1d5b955c34444
+  TrikotFrameworkName: d0d26ed18a715c0d432cf37470364b7098b025f4
 
 PODFILE CHECKSUM: 6a8683a9715cb46f8d61fd61791deda2e19d3751
 

--- a/ios/iosApp.xcodeproj/project.pbxproj
+++ b/ios/iosApp.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 				40171A17226663B300C0D218 /* Embed Frameworks */,
 				94063A99AC7D0CFF679D2D30 /* [CP] Embed Pods Frameworks */,
 				1FBAC30C22A834EF008281E9 /* Run SwiftLint */,
+				C9D04584C961613DF471163A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -248,6 +249,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C9D04584C961613DF471163A /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FACE459D53684FB80E370EBC /* [CP] Check Pods Manifest.lock */ = {


### PR DESCRIPTION
## Description
Change quotes API as the old one was no longer running.
Update kotlin, android and other libraries versions.
Remove code coverage plugin, it was forcing an old version of kotlin

Switches to cocoapod gradle plugin in VMD and VM sample projects.

Cocoapod gradle plugin will regenerate the common podspecs when syncing the gradle project. There is no longer a need for `copyFramework` task as it will call `syncFramework` gradle task ( https://github.com/JetBrains/kotlin/blob/d77041aad06a4a1810b641a20dd8162a14b5ba28/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt#L176 )

I wasn't sure if it was worth it to keep the podspec under source control but I did leave it just in case someone builds ios app without running gradle sync first.

In summary
```mermaid
graph
    A[Gradle sync] -->|calls podspec task| B(common podspec generated)
    B --> C(bundle exec pod install)
    C -->|creates script phase| D(xcode build)
    D -->|calls gradle syncFramework task| E(common framework created)
```
## Motivation and Context
This will simplify and optimize current build setup.

## How Has This Been Tested?
Tested using sample apps.

## Types of changes
Build simplification and optimization.
