### PR TITLE
Add SwiftFormat

### DIFF
--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -126,7 +126,6 @@ curl https://fcm.googleapis.com/fcm/send -X POST \
 
 4. XCode Setup (Preferences)
   - XCode -> Preferences... ~> Text Editing ~> Display => Uncheck 'Wrap lines to editor width'
-  - XCode -> Preferences... ~> Text Editing ~> Indentation => Select 'Prefer Indent Using': Tabs
 
 #### Run
 

--- a/ios/.swiftformat
+++ b/ios/.swiftformat
@@ -28,7 +28,7 @@
 --hexliteralcase uppercase
 --ifdef indent
 --importgrouping alpha
---indent tab
+--indent 4
 --indentcase true
 --indentstrings false
 --lifecycle 

--- a/ios/iosApp/AppDelegate.swift
+++ b/ios/iosApp/AppDelegate.swift
@@ -4,49 +4,49 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-	var window: UIWindow?
+    var window: UIWindow?
 
-	// swiftlint:disable discouraged_optional_collection
-	func application(
-		_: UIApplication,
-		didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
-	) -> Bool {
-		Environment().flavor = currentFlavor()
-		HttpConfiguration().httpRequestFactory = TrikotHttpRequestFactory()
-		HttpConfiguration().connectivityPublisher = TrikotConnectivityService.shared.publisher
-		ImageViewModelResourceManager.shared = SampleImageResourceProvider()
-		TrikotKword.shared.setCurrentLanguage("en")
+    // swiftlint:disable discouraged_optional_collection
+    func application(
+        _: UIApplication,
+        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        Environment().flavor = currentFlavor()
+        HttpConfiguration().httpRequestFactory = TrikotHttpRequestFactory()
+        HttpConfiguration().connectivityPublisher = TrikotConnectivityService.shared.publisher
+        ImageViewModelResourceManager.shared = SampleImageResourceProvider()
+        TrikotKword.shared.setCurrentLanguage("en")
 
-		let window = UIWindow(frame: UIScreen.main.bounds)
-		self.window = window
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        self.window = window
 
-		window.rootViewController = HomeViewController()
+        window.rootViewController = HomeViewController()
 
-		window.makeKeyAndVisible()
+        window.makeKeyAndVisible()
 
-		return true
-	}
+        return true
+    }
 
-	func applicationWillResignActive(_: UIApplication) {
-		TrikotConnectivityService.shared.stop()
-	}
+    func applicationWillResignActive(_: UIApplication) {
+        TrikotConnectivityService.shared.stop()
+    }
 
-	func applicationDidEnterBackground(_: UIApplication) {}
+    func applicationDidEnterBackground(_: UIApplication) {}
 
-	func applicationWillEnterForeground(_: UIApplication) {}
+    func applicationWillEnterForeground(_: UIApplication) {}
 
-	func applicationDidBecomeActive(_: UIApplication) {
-		TrikotConnectivityService.shared.start()
-	}
+    func applicationDidBecomeActive(_: UIApplication) {
+        TrikotConnectivityService.shared.start()
+    }
 
-	func applicationWillTerminate(_: UIApplication) {}
+    func applicationWillTerminate(_: UIApplication) {}
 
-	func currentFlavor() -> Environment.Flavor {
-		switch (Bundle.main.object(forInfoDictionaryKey: "Environment") ?? "debug") as! String {
-			case "debug": return .debug
-			case "qa": return .qa
-			case "staging": return .staging
-			default: return Environment.Flavor.release_
-		}
-	}
+    func currentFlavor() -> Environment.Flavor {
+        switch (Bundle.main.object(forInfoDictionaryKey: "Environment") ?? "debug") as! String {
+            case "debug": return .debug
+            case "qa": return .qa
+            case "staging": return .staging
+            default: return Environment.Flavor.release_
+        }
+    }
 }

--- a/ios/iosApp/SharedBootstrap.swift
+++ b/ios/iosApp/SharedBootstrap.swift
@@ -2,11 +2,11 @@ import Foundation
 import TrikotFrameworkName
 
 class Core {
-	static let shared = Core()
-	private var bootstrap = Bootstrap()
-	let viewModelControllerFactory: ViewModelControllerFactory
+    static let shared = Core()
+    private var bootstrap = Bootstrap()
+    let viewModelControllerFactory: ViewModelControllerFactory
 
-	init() {
-		viewModelControllerFactory = bootstrap.viewModelControllerFactory
-	}
+    init() {
+        viewModelControllerFactory = bootstrap.viewModelControllerFactory
+    }
 }

--- a/ios/iosApp/UI/BaseViewModelView.swift
+++ b/ios/iosApp/UI/BaseViewModelView.swift
@@ -2,13 +2,13 @@ import TrikotFrameworkName
 import UIKit
 
 class BaseViewModelView<VM: ViewModel>: UIView {
-	var viewViewModel: VM?
+    var viewViewModel: VM?
 
-	override required init(frame: CGRect) {
-		super.init(frame: frame)
-	}
+    override required init(frame: CGRect) {
+        super.init(frame: frame)
+    }
 
-	@available(*, unavailable)  required init?(coder _: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
-	}
+    @available(*, unavailable) required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }

--- a/ios/iosApp/UI/BaseViewModelViewController.swift
+++ b/ios/iosApp/UI/BaseViewModelViewController.swift
@@ -2,32 +2,32 @@ import TrikotFrameworkName
 import UIKit
 
 class BaseViewModelViewController<
-	V: BaseViewModelView<VM>,
-	ND: BaseNavigationDelegate,
-	VM: ViewModel,
-	VMC: BaseViewModelController<ND, VM>
+    V: BaseViewModelView<VM>,
+    ND: BaseNavigationDelegate,
+    VM: ViewModel,
+    VMC: BaseViewModelController<ND, VM>
 >: UIViewController {
-	var mainView: V {
-		view as! V
-	}
+    var mainView: V {
+        view as! V
+    }
 
-	let viewModelController: VMC
+    let viewModelController: VMC
 
-	init(viewModelController: VMC) {
-		self.viewModelController = viewModelController
-		super.init(nibName: nil, bundle: nil)
-	}
+    init(viewModelController: VMC) {
+        self.viewModelController = viewModelController
+        super.init(nibName: nil, bundle: nil)
+    }
 
-	@available(*, unavailable)  required init?(coder _: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
-	}
+    @available(*, unavailable) required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
-	override func loadView() {
-		view = V(frame: .zero)
-		mainView.viewViewModel = viewModelController.viewModel
-	}
+    override func loadView() {
+        view = V(frame: .zero)
+        mainView.viewViewModel = viewModelController.viewModel
+    }
 
-	deinit {
-		viewModelController.onCleared()
-	}
+    deinit {
+        viewModelController.onCleared()
+    }
 }

--- a/ios/iosApp/sample/HomeView.swift
+++ b/ios/iosApp/sample/HomeView.swift
@@ -2,36 +2,36 @@ import TrikotFrameworkName
 import UIKit
 
 class HomeView: BaseViewModelView<HomeViewModel> {
-	private let label = UILabel()
-	private let button = UIButton()
+    private let label = UILabel()
+    private let button = UIButton()
 
-	override var viewViewModel: HomeViewModel? {
-		didSet {
-			label.labelViewModel = viewViewModel?.quoteLabel
-			button.buttonViewModel = viewViewModel?.refreshButton
-		}
-	}
+    override var viewViewModel: HomeViewModel? {
+        didSet {
+            label.labelViewModel = viewViewModel?.quoteLabel
+            button.buttonViewModel = viewViewModel?.refreshButton
+        }
+    }
 
-	required init(frame: CGRect) {
-		super.init(frame: frame)
-		label.font = UIFont.boldSystemFont(ofSize: 30)
-		label.textColor = .white
-		label.textAlignment = .center
-		label.numberOfLines = 0
-		label.translatesAutoresizingMaskIntoConstraints = false
-		addSubview(label)
-		button.translatesAutoresizingMaskIntoConstraints = false
-		addSubview(button)
-		button.backgroundColor = .gray
-		NSLayoutConstraint.activate(
-			[
-				label.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
-				label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
-				label.centerXAnchor.constraint(equalTo: centerXAnchor),
-				label.centerYAnchor.constraint(equalTo: centerYAnchor),
-				button.centerXAnchor.constraint(equalTo: centerXAnchor),
-				button.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -50)
-			]
-		)
-	}
+    required init(frame: CGRect) {
+        super.init(frame: frame)
+        label.font = UIFont.boldSystemFont(ofSize: 30)
+        label.textColor = .white
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(button)
+        button.backgroundColor = .gray
+        NSLayoutConstraint.activate(
+            [
+                label.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
+                label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+                label.centerXAnchor.constraint(equalTo: centerXAnchor),
+                label.centerYAnchor.constraint(equalTo: centerYAnchor),
+                button.centerXAnchor.constraint(equalTo: centerXAnchor),
+                button.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -50)
+            ]
+        )
+    }
 }

--- a/ios/iosApp/sample/HomeViewController.swift
+++ b/ios/iosApp/sample/HomeViewController.swift
@@ -2,12 +2,12 @@ import TrikotFrameworkName
 import UIKit
 
 class HomeViewController: BaseViewModelViewController<
-	HomeView,
-	BaseNavigationDelegate,
-	HomeViewModel,
-	HomeViewModelController
+    HomeView,
+    BaseNavigationDelegate,
+    HomeViewModel,
+    HomeViewModelController
 > {
-	init() {
-		super.init(viewModelController: Core.shared.viewModelControllerFactory.createHome())
-	}
+    init() {
+        super.init(viewModelController: Core.shared.viewModelControllerFactory.createHome())
+    }
 }

--- a/ios/iosApp/sample/SampleImageResourceProvider.swift
+++ b/ios/iosApp/sample/SampleImageResourceProvider.swift
@@ -3,7 +3,7 @@ import Trikot
 import TrikotFrameworkName
 
 class SampleImageResourceProvider: ImageViewModelResourceProvider {
-	func image(fromResource _: ImageResource?) -> UIImage? {
-		nil
-	}
+    func image(fromResource _: ImageResource?) -> UIImage? {
+        nil
+    }
 }


### PR DESCRIPTION
## 📖 Description

This PR add a SwiftFormat setup:
- .swiftformat config file (rules can be adjusted)
- setup instructions added to boilerplate_readme.md

It is needed to ensure consistent styling in Swift code across all Mirego projects. The **formatOnSave** features helps developers to focus on how the code works instead of how it looks. It also reduces unnecessary non-functional git diffs (additional newlines, spaces, return after function, etc).

## 📝 Notes

```swiftformat --lint``` has not been added to the CI workflow. The formatting also has to be run artificially if files were modified out of Xcode or if the formatOnSave functionality has not been setup.

## 🦀 Dispatch

- `#dispatch/kmp`
